### PR TITLE
Consistent SQLite spelling, grammar fixes, line breaks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@
 
 # Sqlitex
 
-An Elixir wrapper around [esqlite](https://github.com/mmzeeman/esqlite). The main aim here is to provide convenient usage of sqlite databases.
+An Elixir wrapper around [esqlite](https://github.com/mmzeeman/esqlite). The main aim here is to provide convenient usage of SQLite databases.
 
 # Updated to 1.0
 
-With the 1.0 release we made just a single breaking change. `Sqlitex.Query.query` previously returned just the raw query results on success and `{:error, reason}` on failure.
-This has been bothering us for a while so we changed it in 1.0 to return `{:ok, results}` on success and `{:error, reason}` on failure.
+With the 1.0 release, we made just a single breaking change. `Sqlitex.Query.query` previously returned just the raw query results on success and `{:error, reason}` on failure.
+This has been bothering us for a while, so we changed it in 1.0 to return `{:ok, results}` on success and `{:error, reason}` on failure.
 This should make it easier to pattern match on. The `Sqlitex.Query.query!` function has kept its same functionality of returning bare results on success and raising an error on failure.
 
 # Usage
 
-The simple way to use sqlitex is just to open a database and run a query
+The simple way to use `sqlitex` is just to open a database and run a query:
 
 ```elixir
 Sqlitex.with_db('test/fixtures/golfscores.sqlite3', fn(db) ->
@@ -36,21 +36,21 @@ Sqlitex.with_db('test/fixtures/golfscores.sqlite3', fn(db) ->
   Sqlitex.query(
     db,
     "INSERT INTO players (name, created_at, updated_at) VALUES (?1, ?2, ?3, ?4)",
-    bind: ['Mikey', '2012-10-14 05:46:28.318107', '2013-09-06 22:29:36.610911'])
+    bind: ['Mikey', '2012-10-14 05:46:28.318107', '2013-09-06 22:29:36.610911']
+  )
 end)
 # => [[id: 1, name: "Mikey", created_at: {{2012,10,14},{05,46,28}}, updated_at: {{2013,09,06},{22,29,36}}, type: nil]]
-
 ```
 
-If you want to keep the database open during the lifetime of your project you can use the `Sqlitex.Server` GenServer module.
+If you want to keep the database open during the lifetime of your project, you can use the `Sqlitex.Server` GenServer module.
 Here's a sample from a phoenix projects main supervisor definition.
+
 ```elixir
 children = [
-      # Start the endpoint when the application starts
-      worker(Golf.Endpoint, []),
-
-      worker(Sqlitex.Server, ['golf.sqlite3', [name: Golf.DB]])
-    ]
+  # Start the endpoint when the application starts
+  worker(Golf.Endpoint, []),
+  worker(Sqlitex.Server, ['golf.sqlite3', [name: Golf.DB]])
+]
 ```
 
 Now that the GenServer is running you can make queries via
@@ -63,4 +63,4 @@ Sqlitex.Server.query(Golf.DB,
 ```
 
 # Looking for Ecto?
-Check out the [Sqlite Ecto2 adapter](https://github.com/Sqlite-Ecto/sqlite_ecto2)
+Check out the [SQLite Ecto2 adapter](https://github.com/Sqlite-Ecto/sqlite_ecto2)

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -8,7 +8,7 @@ defmodule Sqlitex do
   @type sqlite_error :: {:error, {:sqlite_error, charlist}}
 
   @moduledoc """
-  Sqlitex gives you a way to create and query sqlite databases.
+  Sqlitex gives you a way to create and query SQLite databases.
 
   ## Basic Example
 
@@ -30,7 +30,7 @@ defmodule Sqlitex do
   Sqlitex uses the Erlang library [esqlite](https://github.com/mmzeeman/esqlite)
   which accepts a timeout parameter for almost all interactions with the database.
   The default value for this timeout is 5000 ms. Many functions in Sqlitex accept
-  a `:db_timeout` option that is passed on to the esqlite calls and that also defaults
+  a `:db_timeout` option that is passed on to the esqlite calls and also defaults
   to 5000 ms. If required, this default value can be overridden globally with the
   following in your `config.exs`:
 
@@ -78,8 +78,8 @@ defmodule Sqlitex do
   def query_rows!(db, sql, opts \\ []), do: Sqlitex.Query.query_rows!(db, sql, opts)
 
   @doc """
-  Create a new table `name` where `table_opts` are a list of table constraints
-  and `cols` are a keyword list of columns. The following table constraints are
+  Create a new table `name` where `table_opts` is a list of table constraints
+  and `cols` is a keyword list of columns. The following table constraints are
   supported: `:temp` and `:primary_key`. Example:
 
   **[:temp, {:primary_key, [:id]}]**

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -6,7 +6,7 @@ defmodule Sqlitex.Query do
 
   ## Parameters
 
-  * `db` - A sqlite database.
+  * `db` - A SQLite database.
   * `sql` - The query to run as a string.
   * `opts` - Options to pass into the query.  See below for details.
 
@@ -16,7 +16,7 @@ defmodule Sqlitex.Query do
     to bind as a list.
   * `into` - The collection to put results into.  This defaults to a list.
   * `db_timeout` - The timeout (in ms) to apply to each of the underlying SQLite operations. Defaults
-    to `Application.get_env(:sqlitex, :db_timeout)` or `5000`ms if not configured.
+    to `Application.get_env(:sqlitex, :db_timeout)` or `5000` ms if not configured.
 
   ## Returns
   * [results...] on success
@@ -56,7 +56,7 @@ defmodule Sqlitex.Query do
 
   ## Parameters
 
-  * `db` - A sqlite database.
+  * `db` - A SQLite database.
   * `sql` - The query to run as a string.
   * `opts` - Options to pass into the query.  See below for details.
 
@@ -65,7 +65,7 @@ defmodule Sqlitex.Query do
   * `bind` - If your query has parameters in it, you should provide the options
     to bind as a list.
   * `db_timeout` - The timeout (in ms) to apply to each of the underlying SQLite operations. Defaults
-    to `Application.get_env(:sqlitex, :db_timeout)` or `5000`ms if not configured.
+    to `Application.get_env(:sqlitex, :db_timeout)` or `5000` ms if not configured.
 
   ## Returns
   * {:ok, %{rows: [[1, 2], [2, 3]], columns: [:a, :b], types: [:INTEGER, :INTEGER]}} on success

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -1,7 +1,7 @@
 defmodule Sqlitex.Server do
   @moduledoc """
   Sqlitex.Server provides a GenServer to wrap a sqlitedb.
-  This makes it easy to share a sqlite database between multiple processes without worrying about concurrency issues.
+  This makes it easy to share a SQLite database between multiple processes without worrying about concurrency issues.
   You can also register the process with a name so you can query by name later.
 
   ## Unsupervised Example
@@ -142,10 +142,10 @@ defmodule Sqlitex.Server do
   cached in the Server process. If a subsequent call to `query/3` or `query_rows/3`
   is made with a matching SQL statement, the prepared statement is reused.
 
-  Prepared statements are purged from the cache when the cache exceeds a pre-set
+  Prepared statements are purged from the cache when the cache exceeds a preset
   limit (20 statements by default).
 
-  Returns summary information about the prepared statement
+  Returns summary information about the prepared statement.
   `{:ok, %{columns: [:column1_name, :column2_name,... ], types: [:column1_type, ...]}}`
   on success or `{:error, {:reason_code, 'SQLite message'}}` if the statement
   could not be prepared.

--- a/lib/sqlitex/server/statement_cache.ex
+++ b/lib/sqlitex/server/statement_cache.ex
@@ -19,7 +19,7 @@ defmodule Sqlitex.Server.StatementCache do
   Given a statement cache and an SQL statement (string), returns a tuple containing
   the updated statement cache and a prepared SQL statement.
 
-  If possible, reuses an existing prepared statement; if not, prepares the statement
+  If possible, reuses an existing prepared statement. If not, prepares the statement
   and adds it to the cache, possibly removing the least-recently used prepared
   statement if the designated cache size limit would be exceeded.
 
@@ -63,6 +63,7 @@ defmodule Sqlitex.Server.StatementCache do
               cached_stmts: Map.drop(cached_stmts, [purge_victim]),
               lru: lru}
   end
+
   defp purge_cache_if_full(cache), do: cache
 
   defp update_cache_for_read(%__MODULE__{lru: lru} = cache, sql) do

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -1,7 +1,7 @@
 defmodule Sqlitex.Statement do
   alias Sqlitex.Row
   @moduledoc """
-  Provides an interface for working with sqlite prepared statements.
+  Provides an interface for working with SQLite prepared statements.
 
   Care should be taken when using prepared statements directly - they are not
   immutable objects like most things in Elixir. Sharing a statement between
@@ -115,7 +115,7 @@ defmodule Sqlitex.Statement do
   end
 
   @doc """
-  Binds values to a Sqlitex.Statement
+  Binds values to a Sqlitex.Statement.
 
   ## Parameters
 
@@ -226,7 +226,7 @@ defmodule Sqlitex.Statement do
     timeout = Keyword.get(opts, :db_timeout, Config.db_timeout())
 
     case :esqlite3.step(statement.statement, timeout) do
-      # esqlite3.step returns some odd values, so lets translate them:
+      # esqlite3.step returns some odd values, so let's translate them:
       :"$done" -> :ok
       :"$busy" -> {:error, {:busy, "Sqlite database is busy"}}
       other -> other
@@ -323,14 +323,17 @@ defmodule Sqlitex.Statement do
     [table | cols] = String.split(values, ",")
     {table, cols, "INSERT", "NEW"}
   end
+
   defp parse_return_contents(<<"UPDATE ", values::binary>>) do
     [table | cols] = String.split(values, ",")
     {table, cols, "UPDATE", "NEW"}
   end
+
   defp parse_return_contents(<<"DELETE ", values::binary>>) do
     [table | cols] = String.split(values, ",")
     {table, cols, "DELETE", "OLD"}
   end
+
   defp parse_return_contents(_) do
     {:error, :invalid_returning_clause}
   end


### PR DESCRIPTION
SQLite was spelling inconsistently in the README.md and comments (sometimes `sqlite`, sometimes `SQLite`). Normalized on the capitalized version.

Additionally, there were some run-on sentences, which were broken apart with commas. Also, added line breaks between functions where needed.